### PR TITLE
Use unique instance id as runner name, to prevent name clash

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -19,3 +21,11 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint
+      - name: Package
+        run: npm run package
+      - name: Commit
+        run: |
+          git config --global user.name "GitHub Actions"
+          git add dist/
+          git commit -m "Update dist" || echo "No changes to commit"
+          git push -f origin HEAD:refs/heads/artifact/pr-${{github.event.number}}

--- a/src/aws.js
+++ b/src/aws.js
@@ -12,7 +12,8 @@ function buildUserDataScript(githubRegistrationToken, label) {
       `cd "${config.input.runnerHomeDir}"`,
       'export RUNNER_ALLOW_RUNASROOT=1',
       'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+      'export INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)',
+      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --name $INSTANCE_ID --labels ${label}`,
       './run.sh',
     ];
   } else {
@@ -20,11 +21,12 @@ function buildUserDataScript(githubRegistrationToken, label) {
       '#!/bin/bash',
       'mkdir actions-runner && cd actions-runner',
       'case $(uname -m) in aarch64) ARCH="arm64" ;; amd64|x86_64) ARCH="x64" ;; esac && export RUNNER_ARCH=${ARCH}',
-      'curl -O -L https://github.com/actions/runner/releases/download/v2.280.3/actions-runner-linux-${RUNNER_ARCH}-2.280.3.tar.gz',
-      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.280.3.tar.gz',
+      'curl -O -L https://github.com/actions/runner/releases/download/v2.284.0/actions-runner-linux-${RUNNER_ARCH}-2.284.0.tar.gz',
+      'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.284.0.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+      'export INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)',
+      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --name $INSTANCE_ID --labels ${label}`,
       './run.sh',
     ];
   }

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,10 @@ class Config {
     const tags = JSON.parse(core.getInput('aws-resource-tags'));
     this.tagSpecifications = null;
     if (tags.length > 0) {
-      this.tagSpecifications = [{ResourceType: 'instance', Tags: tags}, {ResourceType: 'volume', Tags: tags}];
+      this.tagSpecifications = [
+        { ResourceType: 'instance', Tags: tags },
+        { ResourceType: 'volume', Tags: tags },
+      ];
     }
 
     // the values of github.context.repo.owner and github.context.repo.repo are taken from
@@ -47,7 +50,7 @@ class Config {
         throw new Error(`Not all the required inputs are provided for the 'start' mode`);
       }
     } else if (this.input.mode === 'stop') {
-      if (!this.input.label || !this.input.ec2InstanceId) {
+      if (!this.input.ec2InstanceId) {
         throw new Error(`Not all the required inputs are provided for the 'stop' mode`);
       }
     } else {

--- a/src/gh.js
+++ b/src/gh.js
@@ -3,18 +3,18 @@ const github = require('@actions/github');
 const _ = require('lodash');
 const config = require('./config');
 
-const INITIAL_WAIT_TIME_BEFORE_CHECKS = 5 * 1000; // 5 seconds
+const INITIAL_WAIT_TIME_BEFORE_CHECKS = 4 * 1000; // 5 seconds
 const MAX_WAIT_TIME_BEFORE_FAIL = 15 * 60 * 1000; // 15 minutes
 const MAX_WAIT_TIME_BETWEEN_REGISTERED_CHECKS = 60 * 1000; // 60 seconds
 
 // use the unique label to find the runner
 // as we don't have the runner's id, it's not possible to get it in any other way
-async function getRunner(label) {
+async function getRunner(runnerId) {
   const octokit = github.getOctokit(config.input.githubToken);
 
   try {
     const runners = await octokit.paginate('GET /repos/{owner}/{repo}/actions/runners', config.githubContext);
-    const foundRunners = _.filter(runners, { labels: [{ name: label }] });
+    const foundRunners = _.filter(runners, (runner) => runner.name === runnerId);
     return foundRunners.length > 0 ? foundRunners[0] : null;
   } catch (error) {
     return null;
@@ -36,12 +36,12 @@ async function getRegistrationToken() {
 }
 
 async function removeRunner() {
-  const runner = await getRunner(config.input.label);
+  const runner = await getRunner(config.input.ec2InstanceId ? config.input.ec2InstanceId : config.input.label);
   const octokit = github.getOctokit(config.input.githubToken);
 
   // skip the runner removal process if the runner is not found
   if (!runner) {
-    core.info(`GitHub self-hosted runner with label ${config.input.label} is not found, so the removal is skipped`);
+    core.info(`GitHub self-hosted runner with id ${config.input.label} is not found, so the removal is skipped`);
     return;
   }
 
@@ -55,10 +55,10 @@ async function removeRunner() {
   }
 }
 
-function waitForRunnerRegisteredRecursive(label, resolve, reject, nextDelay, timeoutAfter) {
+function waitForRunnerRegisteredRecursive(runnerId, resolve, reject, nextDelay, timeoutAfter) {
   core.info(`Waiting ${nextDelay / 1000} seconds...`);
   setTimeout(async () => {
-    const runner = await getRunner(label);
+    const runner = await getRunner(runnerId);
     if (runner && runner.status === 'online') {
       core.info(`GitHub self-hosted runner ${runner.name} is registered and ready to use`);
       resolve();
@@ -67,17 +67,18 @@ function waitForRunnerRegisteredRecursive(label, resolve, reject, nextDelay, tim
         core.error('GitHub self-hosted runner registration error');
         reject(`Timeout exceeded: Your AWS EC2 instance was not able to register itself in GitHub as a new self-hosted runner.`);
       } else {
-        waitForRunnerRegisteredRecursive(label, resolve, reject, Math.min(nextDelay * 2, MAX_WAIT_TIME_BETWEEN_REGISTERED_CHECKS), timeoutAfter);
+        const waitFor = Math.min(nextDelay * 1.5, MAX_WAIT_TIME_BETWEEN_REGISTERED_CHECKS);
+        waitForRunnerRegisteredRecursive(runnerId, resolve, reject, waitFor, timeoutAfter);
       }
     }
   }, nextDelay);
 }
 
-function waitForRunnerRegistered(label) {
+function waitForRunnerRegistered(runnerId) {
   core.info(`Checking if the GitHub self-hosted runner is registered, waiting up to ${Math.round(MAX_WAIT_TIME_BEFORE_FAIL / 1000 / 60)} minutes.`);
 
   return new Promise((resolve, reject) => {
-    waitForRunnerRegisteredRecursive(label, resolve, reject, INITIAL_WAIT_TIME_BEFORE_CHECKS, new Date().getTime() + MAX_WAIT_TIME_BEFORE_FAIL);
+    waitForRunnerRegisteredRecursive(runnerId, resolve, reject, INITIAL_WAIT_TIME_BEFORE_CHECKS, new Date().getTime() + MAX_WAIT_TIME_BEFORE_FAIL);
   });
 }
 

--- a/src/gh.js
+++ b/src/gh.js
@@ -3,7 +3,7 @@ const github = require('@actions/github');
 const _ = require('lodash');
 const config = require('./config');
 
-const INITIAL_WAIT_TIME_BEFORE_CHECKS = 4 * 1000; // 5 seconds
+const INITIAL_WAIT_TIME_BEFORE_CHECKS = 4 * 1000; // 4 seconds
 const MAX_WAIT_TIME_BEFORE_FAIL = 15 * 60 * 1000; // 15 minutes
 const MAX_WAIT_TIME_BETWEEN_REGISTERED_CHECKS = 60 * 1000; // 60 seconds
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ async function start() {
   const ec2InstanceId = await aws.startEc2Instance(label, githubRegistrationToken);
   setOutput(label, ec2InstanceId);
   await aws.waitForInstanceRunning(ec2InstanceId);
-  await gh.waitForRunnerRegistered(label);
+  await gh.waitForRunnerRegistered(ec2InstanceId);
 }
 
 async function stop() {


### PR DESCRIPTION
Sometimes a GitHub actions job does not cleanup the self-hosted runner
from the list of registered runners. Then a runner with a ip address
as the name is left.

A new runner that does potentially get the same IP as the previous runner
is now no longer able to connect to the GitHub runner API as the runner
is already registered (but offline).

Using the EC2 instance id does ensure that the name is somewhat unique and
does not interfere with left over, not cleaned up offline runners.